### PR TITLE
Fix markupsafe version conflict

### DIFF
--- a/requirements-dl.txt
+++ b/requirements-dl.txt
@@ -4,8 +4,8 @@ torchvision==0.13.0
 torchaudio==0.12.0
 tensorflow==2.9.1; platform_machine == "x86_64"
 tensorflow-aarch64==2.9.1; platform_machine == "aarch64"
-# Markupsafe 2.1.1 introduces a breaking change that messes with older Jupyter.
-# However, werkzeug (required by tensorboard) wants 2.1.1. As a temporary hack,
-# we downgrade markupsafe to keep Jupyter happy. Once the PL upstream image is
-# renovated, this will hopefully not be necessary.
+# Werkzeug (required by tensorboard) wants Markupsafe 2.1.1.
+# However, 2.0.1 is required by the older Jupyter that PL's upstream image still uses.
+# As a temporary hack, we downgrade markupsafe to keep Jupyter happy.
+# Once the PL upstream image is renovated, this will hopefully not be necessary.
 markupsafe==2.0.1

--- a/requirements-dl.txt
+++ b/requirements-dl.txt
@@ -4,3 +4,8 @@ torchvision==0.13.0
 torchaudio==0.12.0
 tensorflow==2.9.1; platform_machine == "x86_64"
 tensorflow-aarch64==2.9.1; platform_machine == "aarch64"
+# Markupsafe 2.1.1 introduces a breaking change that messes with older Jupyter.
+# However, werkzeug (required by tensorboard) wants 2.1.1. As a temporary hack,
+# we downgrade markupsafe to keep Jupyter happy. Once the PL upstream image is
+# renovated, this will hopefully not be necessary.
+markupsafe==2.0.1


### PR DESCRIPTION
Favoring Jupyter's outdated preference over Werkzeug's (Tensorboard's). Fixes Jupyter but this will also cause Werkzeug to be downgraded as a result. Not sure if Tensorboard will work properly until a more complete overhaul of the PL upstream image is done.